### PR TITLE
Base title is now generated for pages that don't have their own title name; removed 'home' from the homepage title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  # Returns the full title on a per-page basis.
+  def full_title(page_title = '')
+    base_title = "Ruby on Rails Sample Application"
+    if page_title.empty?
+      base_title
+    else
+      page_title + " | " + base_title
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Sample Application</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -1,4 +1,4 @@
-<% provide(:title, "About") %>
+<% provide(:title, "About") %> <!-- Call the 'provide' function and associate the string "Home" with the label ':title' -->
 <h1>About!</h1>
 <p>
   This website is

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,3 @@
-<% provide(:title, "Home") %> <!-- Call the 'provide' function and associate the string "Home" with the label ':title' -->
 <h1>Ari's Sample App!</h1>
 <p>
   This is the home page for

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -12,13 +12,13 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test "should get root" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home | #{@base_title}"
+    assert_select "title", "#{@base_title}"
   end
 
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home | #{@base_title}"
+    assert_select "title", "#{@base_title}"
   end
 
   test "should get help" do


### PR DESCRIPTION
Base title is now generated for pages that don't have their own title name; removed 'home' from the homepage title